### PR TITLE
fix: user change

### DIFF
--- a/src/main/java/com/goormthon/tomado/domain/user/entity/User.java
+++ b/src/main/java/com/goormthon/tomado/domain/user/entity/User.java
@@ -74,10 +74,10 @@ public class User {
      * - null 값이 들어올 경우
      */
     public User change(ChangeRequest request) {
-        this.loginId = loginId.equals(request.getLogin_id()) || request.getLogin_id() == null ? loginId : request.getLogin_id();
-        this.password = password.equals(request.getPassword()) || request.getPassword() == null ? password : request.getPassword();
-        this.nickname = nickname.equals(request.getNickname()) || request.getNickname() == null ? nickname : request.getNickname();
-        this.characterUrl = characterUrl.equals(request.getCharacter_url()) || request.getCharacter_url() == null ? characterUrl : request.getCharacter_url();
+        this.loginId = loginId.equals(request.getLogin_id()) || request.getLogin_id().isEmpty() ? loginId : request.getLogin_id();
+        this.password = password.equals(request.getPassword()) || request.getPassword().isEmpty() ? password : request.getPassword();
+        this.nickname = nickname.equals(request.getNickname()) || request.getNickname().isEmpty() ? nickname : request.getNickname();
+        this.characterUrl = characterUrl.equals(request.getCharacter_url()) || request.getCharacter_url().isEmpty() ? characterUrl : request.getCharacter_url();
 
         return this;
     }

--- a/src/main/java/com/goormthon/tomado/domain/user/service/UserService.java
+++ b/src/main/java/com/goormthon/tomado/domain/user/service/UserService.java
@@ -76,7 +76,12 @@ public class UserService {
 
         User user = userRepository.findById(user_id)
                 .orElseThrow(() -> new NotFoundException(USER_NOT_EXIST));
-        request.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        if (request.getPassword().isEmpty()) {
+            request.setPassword(request.getPassword());
+        } else {
+            request.setPassword(passwordEncoder.encode(request.getPassword()));
+        }
 
         try {
             User userChanged = userRepository.save(user.change(request));


### PR DESCRIPTION
- 빈 값을 보낼 때 값이 그대로 들어가는 현상 수정
  - request body에서 ""가 들어올 경우, null이 아니라 isEmpty()로 처리 필요
- 비밀번호가 isEmpty일 경우, encode를 pass하지 않도록 변경

## 개요
- close #36 

## 작업사항
- 회원 수정 오류 수정

## 변경로직
- 내용을 적어주세요.
